### PR TITLE
RDKB-64090 : Hotspot gre tunnels not created though Hotspot SSID are up impacting hotspot client connectivity

### DIFF
--- a/source/hotspotfd/hotspotfd.c
+++ b/source/hotspotfd/hotspotfd.c
@@ -1117,18 +1117,6 @@ STATIC bool hotspot_check_wan_failover_status(char *val)
              CcspTraceError(("sysevent set %s failed on %s\n", kHotspotfd_tunnelEP, __FUNCTION__));
          }
      }
-     else
-     {
-         /* Tunnel and VLAN bridges were already fully created by wanfailover_handleTunnel(true).
-          * Reset gbFirstPrimarySignal and gTunnelIsUp so the keep-alive ping thread does not
-          * fire sysevent kHotspotfd_tunnelEP again, which would cause the GRE EP script to
-          * destroy and recreate gretap0, removing all VLAN sub-interfaces from their bridges. */
-         gTunnelIsUp = true;
-         pthread_mutex_lock(&keep_alive_mutex);
-         gbFirstPrimarySignal = false;
-         pthread_mutex_unlock(&keep_alive_mutex);
-         CcspTraceInfo(("Tunnel restored by wanfailover_handleTunnel, resetting firstPrimarySignal in %s\n", __FUNCTION__));
-     }
      return true;
 }
 #endif

--- a/source/hotspotfd/hotspotfd.c
+++ b/source/hotspotfd/hotspotfd.c
@@ -1117,6 +1117,18 @@ STATIC bool hotspot_check_wan_failover_status(char *val)
              CcspTraceError(("sysevent set %s failed on %s\n", kHotspotfd_tunnelEP, __FUNCTION__));
          }
      }
+     else
+     {
+         /* Tunnel and VLAN bridges were already fully created by wanfailover_handleTunnel(true).
+          * Reset gbFirstPrimarySignal and gTunnelIsUp so the keep-alive ping thread does not
+          * fire sysevent kHotspotfd_tunnelEP again, which would cause the GRE EP script to
+          * destroy and recreate gretap0, removing all VLAN sub-interfaces from their bridges. */
+         gTunnelIsUp = true;
+         pthread_mutex_lock(&keep_alive_mutex);
+         gbFirstPrimarySignal = false;
+         pthread_mutex_unlock(&keep_alive_mutex);
+         CcspTraceInfo(("Tunnel restored by wanfailover_handleTunnel, resetting firstPrimarySignal in %s\n", __FUNCTION__));
+     }
      return true;
 }
 #endif

--- a/source/hotspotfd/hotspotfd.c
+++ b/source/hotspotfd/hotspotfd.c
@@ -1060,7 +1060,6 @@ STATIC bool hotspot_isRemoteWan(char *wan_interface)
  
      if ( (strcmp(wan_interface, psm_val) == 0)){
          wanFailover = true;
-#if !defined(RDK_ONEWIFI)
         if(TRUE == get_validate_ssid())
         {
             CcspTraceInfo(("SSID values are updated successfully before setting tunnel status down\n"));
@@ -1069,13 +1068,11 @@ STATIC bool hotspot_isRemoteWan(char *wan_interface)
         {
             CcspTraceInfo(("SSID values not are updated successfully before setting tunnel status down\n"));
         }
-#endif
          notify_tunnel_status("Down");
          return true;
      }
      else{
          wanFailover = false;
-#if !defined(RDK_ONEWIFI)
         if(TRUE == set_validatessid())
         {
             CcspTraceInfo(("SSID's updated before creating tunnels before setting tunnel status up. \n"));
@@ -1084,7 +1081,6 @@ STATIC bool hotspot_isRemoteWan(char *wan_interface)
         {
             CcspTraceInfo(("SSID's are not updated before creating tunnels before setting tunnel status up. \n"));
         }
-#endif
          notify_tunnel_status("Up");
          return false;
      }


### PR DESCRIPTION
RDKB-64090: Upon WAN restore gretaps not created

Reason for change: SSIDs are not updated before WAN failover.
Test Procedure: Remove the RF feed to trigger the WFO and connect back.
Risks: High
Priority: P0
Signed-off-by: BalajiChowdary_Unnam@comcast.com