### PR TITLE
RDKB-66227: Not removing Bridges Incase of Hotspot Disable and wan Failover.

### DIFF
--- a/source/HotspotApi/HotspotApi.c
+++ b/source/HotspotApi/HotspotApi.c
@@ -501,9 +501,11 @@ static int deleteVaps()
                                 "%s %s ; ",
                                   IP_DEL, gVlanSyncData[index].vapInterface);
 #endif
+#if 0  /*RDKB-66227:Bridge deletion was skipped because EAPD relies on these bridges. */
             offset += snprintf(cmdBuf+offset,
                                 sizeof(cmdBuf) - offset,
                                 "%s %s ; ", IP_DEL, gVlanSyncData[index].bridgeName);
+#endif
             offset += snprintf(cmdBuf+offset,
                                 sizeof(cmdBuf) - offset,
                                 "%s %s ;", IP_DEL, GRE_IFNAME);
@@ -1533,9 +1535,11 @@ static int wanfailover_handleTunnel(bool create)
                                 "%s %s ; ",
                                 IP_DEL, gVlanSyncData[index].vapInterface);
 #endif
+#if 0  /*RDKB-66227:Bridge deletion was skipped because EAPD relies on these bridges. */
             offset += snprintf(cmdBuf+offset,
                                 sizeof(cmdBuf) - offset,
                                 "%s %s ; ", IP_DEL, gVlanSyncData[index].bridgeName);
+#endif
             offset += snprintf(cmdBuf+offset,
                                 sizeof(cmdBuf) - offset,
                                 "%s %s ;", IP_DEL, GRE_IFNAME);


### PR DESCRIPTION
Reason for change: For testing
Test Procedure: On target Functional Testing
Risks: Medium
Priority:P1
Signed-off-by:Jayasri Kadiyala [Jayasri_Kadiyala@comcast.com](mailto:Jayasri_Kadiyala@comcast.com)